### PR TITLE
release/0.0.2

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,14 +39,16 @@ jobs:
             pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
             pre-commit-
 
-      - name: Install pre-commit
+      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
           python -m pip install pre-commit
           pre-commit --version
         shell: bash
 
-      - name: Install pre-commit hooks
+      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        name: Install pre-commit hooks
         run: pre-commit install
         shell: bash
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,6 +35,9 @@ jobs:
             ~/.cache/pre-commit
             ~/.cache/pip
           key: pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+            pre-commit-
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,8 +39,7 @@ jobs:
             pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
             pre-commit-
 
-      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        name: Install pre-commit
+      - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
           python -m pip install pre-commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,4 @@ jobs:
       - name: gh release create
         if: env.exists == 'false' && (env.RELEASE_TYPE == 'final' || env.RELEASE_TYPE == 'post')
         run: |
-          gh release create --generate-notes --title "Release $VERSION" "$VERSION"
+          gh release create --draft --generate-notes --title "Release $VERSION" "$VERSION"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Code Quality](https://github.com/azataiot/python-project-template/actions/workflows/code-quality.yml/badge.svg)](https://github.com/azataiot/python-project-template/actions/workflows/code-quality.yml)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
-[![latest release](https://img.shields.io/github/v/release/azataiot/python-project-template)](https://github.com/azataiot/python-project-template/releases)
+[![latest release](https://img.shields.io/github/v/release/azataiot/bump-version)](https://github.com/azataiot/bump-version/releases)
 
 **Introduction**: This project is heavily inspired by [bumpversion](https://github.com/peritus/bumpversion), yet this is
 a different package with a different approach and design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bump-version"
-version = "0.0.1"
+version = "0.0.2"
 description = "Version-bump your software with a single command"
 authors = [ "Azat <8280770+azataiot@users.noreply.github.com>",]
 readme = "README.md"


### PR DESCRIPTION
- fix release not found
- adding restore key to github actions
- we don't need to reinstall python packages if a cache is hit
- when restoring from cache, pre-commit is not available globally
- create draft instead of release.yml
- Bump version: 0.0.1 → 0.0.2
