### PR TITLE
release/0.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+on:
+  workflow_run:
+    workflows: [ "Github Release" ] # replace with the name of your release.yml workflow
+    types:
+      - completed
+  workflow_dispatch:
+    if: github.actor != 'dependabot[bot]'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+
+      - name: Setup Cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            ~/.cache/pre-commit
+            ~/.cache/pip
+            .venv
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('**/**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/poetry.lock') }}-
+            ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-
+            ${{ runner.os }}-poetry-
+
+      - name: Install Poetry and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry config virtualenvs.in-project true
+          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          poetry install
+
+      - name: Build and publish
+        run: |
+          source .venv/bin/activate
+          poetry build
+          poetry publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Automatic Release
+name: Github Release
 
 on:
   pull_request:
@@ -45,6 +45,12 @@ jobs:
         if: env.exists == 'true'
         run: |
           gh issue create --title "Release $VERSION already exists" --body "The release for version $VERSION already exists. Please review and take appropriate action."
+
+      - name: Fail if release exists
+        if: env.exists == 'true'
+        run: |
+          echo "Error: Release $VERSION already exists!"
+          exit 1
 
       - name: gh release create
         if: env.exists == 'false' && (env.RELEASE_TYPE == 'final' || env.RELEASE_TYPE == 'post')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches: [ 'main' ]
     types:
       - closed
-      - synchronize
   workflow_dispatch:
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,26 @@ ensure-dev-branch:
 
 
 # -- Dependency --
+
+## Install dependencies
+install: ensure-poetry
+	poetry install
+
+## Update dependencies
+showdeps: ## run poetry to show deps
+	@echo "CURRENT:"
+	poetry show --tree
+	@echo
+	@echo "LATEST:"
+	poetry show --latest
+
 ## Export dependencies to requirements.txt
 requirements: ensure-poetry
 	@echo "Exporting dependencies to requirements.txt..."
 	@poetry export --only main -f requirements.txt --output requirements/requirements.txt --without-hashes
 	@poetry export --only dev -f requirements.txt --output requirements/dev-requirements.txt --without-hashes
 	@echo "Done!"
+
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bump-version"
-version = "0.0.2"
+version = "0.0.3"
 description = "Version-bump your software with a single command"
 authors = [ "Azat <8280770+azataiot@users.noreply.github.com>",]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bump-version"
-version = "0.0.1"
+version = "0.0.2"
 description = "Version-bump your software with a single command"
 authors = [ "Azat <8280770+azataiot@users.noreply.github.com>",]
 readme = "README.md"


### PR DESCRIPTION
- adding restore key to github actions
- we don't need to reinstall python packages if a cache is hit
- when restoring from cache, pre-commit is not available globally
- create draft instead of release.yml
- Bump version: 0.0.1 → 0.0.2
- we want release only run when closed
- faile if exist is true
- trying to test the publish.yml
